### PR TITLE
chore(script): clean up environment setup and run command

### DIFF
--- a/src/scripts/run_md.sh
+++ b/src/scripts/run_md.sh
@@ -1,22 +1,37 @@
-# OpenAI
+#!/bin/bash
+# Environment Variables
+
+## OpenAI
 export OPENAI_API_KEY=""
 export OPENAI_API_BASE=""
-# Wenxin
+
+## Wenxin
 export WENXIN_API_KEY=""
 export WENXIN_SECRET_KEY=""
-# Qwen
-export DASHSCOPE_API_KEY=""
+
+## Qwen
 export DASHSCOPE_API_KEY=""
 
-
+# Run Collaborative Consultation Scenario
 python run.py \
-    --scenario Scenario.CollaborativeConsultation \
-    --patient_database ./data/patients.json \
-    --doctor_database ./data/collaborative_doctors/doctors.json \
-    --patient Agent.Patient.GPT --patient_openai_model_name gpt-3.5-turbo \
-    --reporter Agent.Reporter.GPT --reporter_openai_model_name gpt-3.5-turbo \
-    --host Agent.Host.GPT --host_openai_model_name gpt-4 \
-    --number_of_doctors 2 --max_discussion_turn 4 \
-    --save_path outputs/collaboration_history_iiyi/doctors_2_agent_gpt3_gpt4_wenxin_parallel_with_critique_discussion_history_0222.jsonl \
-    --discussion_mode Parallel_with_Critique # --parallel --max_workers 8
-
+  --scenario Scenario.CollaborativeConsultation \
+  --patient_database ./data/patients.json \
+  --doctor_database ./data/collaborative_doctors/doctors.json \
+  \
+  --patient Agent.Patient.GPT \
+  --patient_openai_model_name gpt-3.5-turbo \
+  \
+  --reporter Agent.Reporter.GPT \
+  --reporter_openai_model_name gpt-3.5-turbo \
+  \
+  --host Agent.Host.GPT \
+  --host_openai_model_name gpt-4 \
+  \
+  --number_of_doctors 2 \
+  --max_discussion_turn 4 \
+  \
+  --save_path outputs/collaboration_history_iiyi/doctors_2_agent_gpt3_gpt4_wenxin_parallel_with_critique_discussion_history_0222.jsonl \
+  \
+  --discussion_mode Parallel_with_Critique
+  # Uncomment for parallel execution:
+  # --parallel --max_workers 8


### PR DESCRIPTION
- Removed duplicate DASHSCOPE_API_KEY export
- Added bash shebang for direct execution
- Grouped env vars by provider (OpenAI, Wenxin, Qwen)
- Reformatted long Python command for better readability
- Added optional parallel execution flags as commented lines